### PR TITLE
fix: warmup_timestep encoder mis-comm

### DIFF
--- a/pipefuser/pipelines/pip/distri_sd3.py
+++ b/pipefuser/pipelines/pip/distri_sd3.py
@@ -298,7 +298,7 @@ class DistriSD3PiP(StableDiffusion3Pipeline):
                 else:
                     self.comm_manager.irecv_from_prev(dtype)
                     latents = self.comm_manager.get_data()
-                    if i == 0:
+                    if distri_config.rank != 1:
                         encoder_hidden_states = self.comm_manager.recv_from_prev(prompt_embeds.dtype, is_extra=True)
                 assert self._interrupt == False
                 # TBD
@@ -331,7 +331,7 @@ class DistriSD3PiP(StableDiffusion3Pipeline):
                 # if XLA_AVAILABLE:
                 #     xm.mark_step()
                 self.comm_manager.isend_to_next(latents)
-                if distri_config.rank != 0 and i == 0:
+                if distri_config.rank != 0:
                     self.comm_manager.send_to_next(next_encoder_hidden_states, is_extra=True)
 
             assert self.comm_manager.recv_queue == []
@@ -359,7 +359,7 @@ class DistriSD3PiP(StableDiffusion3Pipeline):
                     ori_latents = [None for _ in range(pp_num_patch)]
                 else:
                     latents = [None for _ in range(pp_num_patch)]
-
+            
             for i, t in enumerate(pip_timesteps):
 
                 assert self.interrupt == False


### PR DESCRIPTION
Currently, the difference between original image and ours is in a rational range. <del>However, there is still a bug that the 2nd image should be exactly same as the 3rd image, but there are still some subtle discrepancy.</del>

```python
query = torch.cat([query, encoder_hidden_states_query_proj], dim=1)
key = torch.cat([key, encoder_hidden_states_key_proj], dim=1)
value = torch.cat([value, encoder_hidden_states_value_proj], dim=1)
...
hidden_states, encoder_hidden_states = (
            hidden_states[:, : residual.shape[1]],
            hidden_states[:, residual.shape[1] :],
)
```
`encoder_hidden_states` depends on `hidden_states`, so the images will be different with different device number.

<img width="1481" alt="截屏2024-06-28 10 41 48" src="https://github.com/PipeFusion/PipeFusion/assets/36126696/63df75f3-43d1-451f-9bc6-5c365305c830">
