### PR TITLE
feat: split batch for pipefusion parallelism

### DIFF
--- a/pipefuser/models/distri_unet_tp.py
+++ b/pipefuser/models/distri_unet_tp.py
@@ -183,7 +183,7 @@ class DistriUNetTP(BaseModel):  # for Patch Parallelism
                 dist.all_gather(
                     self.buffer_list,
                     output.contiguous(),
-                    group=distri_config.split_group(),
+                    group=distri_config.dp_group(),
                     async_op=False,
                 )
                 torch.cat(self.buffer_list, dim=0, out=self.output_buffer)

--- a/pipefuser/modules/dit/patch_parallel/attn.py
+++ b/pipefuser/modules/dit/patch_parallel/attn.py
@@ -210,7 +210,7 @@ class DistriSelfAttentionPP(DistriAttentionPP):
                     dist.all_gather(
                         self.buffer_list,
                         kv,
-                        group=distri_config.batch_group,
+                        group=distri_config.batch_parallel_group,
                         async_op=False,
                     )
                     full_kv = torch.cat(self.buffer_list, dim=1)

--- a/pipefuser/modules/dit/patch_parallel/conv2d.py
+++ b/pipefuser/modules/dit/patch_parallel/conv2d.py
@@ -135,7 +135,7 @@ class DistriConv2dPP(BaseModule):
                         dist.all_gather(
                             self.buffer_list,
                             boundary,
-                            group=distri_config.batch_group,
+                            group=distri_config.batch_parallel_group,
                             async_op=False,
                         )
                         padded_x = create_padded_x()

--- a/pipefuser/modules/dit/patch_parallel/groupnorm.py
+++ b/pipefuser/modules/dit/patch_parallel/groupnorm.py
@@ -54,7 +54,7 @@ class DistriGroupNorm(BaseModule):
                 dist.all_gather(
                     self.buffer_list,
                     slice_mean,
-                    group=distri_config.batch_group,
+                    group=distri_config.batch_parallel_group,
                     async_op=False,
                 )
                 full_mean = sum(self.buffer_list) / distri_config.n_device_per_batch
@@ -100,7 +100,7 @@ class DistriGroupNorm(BaseModule):
                 )  # [1, num_groups, 1, 1, 1]
                 mean = torch.stack([x_mean, x2_mean], dim=0)
                 dist.all_reduce(
-                    mean, op=dist.ReduceOp.SUM, group=distri_config.batch_group
+                    mean, op=dist.ReduceOp.SUM, group=distri_config.batch_parallel_group
                 )
                 mean = mean / distri_config.n_device_per_batch
                 x_mean = mean[0]

--- a/pipefuser/modules/dit/pipefusion/transformer_2d.py
+++ b/pipefuser/modules/dit/pipefusion/transformer_2d.py
@@ -20,15 +20,15 @@ class DistriTransformer2DModel(BaseModule):
     def __init__(self, module: Transformer2DModel, distri_config: DistriConfig):
         super().__init__(module, distri_config)
         current_rank = (
-            distri_config.rank - 1 + distri_config.world_size
-        ) % distri_config.world_size
+            distri_config.rank - 1 + distri_config.n_device_per_batch
+        ) % distri_config.n_device_per_batch
 
         # logger.info(f"attn_num {distri_config.attn_num}")
         # logger.info(f"{len{self.module.transformer_blocks}}")
 
         if distri_config.attn_num is not None:
             assert sum(distri_config.attn_num) == len(self.module.transformer_blocks)
-            assert len(distri_config.attn_num) == distri_config.world_size
+            assert len(distri_config.attn_num) == distri_config.n_device_per_batch
 
             if current_rank == 0:
                 self.module.transformer_blocks = self.module.transformer_blocks[
@@ -43,8 +43,8 @@ class DistriTransformer2DModel(BaseModule):
         else:
 
             block_len = (
-                len(self.module.transformer_blocks) + distri_config.world_size - 1
-            ) // distri_config.world_size
+                len(self.module.transformer_blocks) + distri_config.n_device_per_batch - 1
+            ) // distri_config.n_device_per_batch
             start_idx = block_len * current_rank
             end_idx = min(
                 block_len * (current_rank + 1), len(self.module.transformer_blocks)

--- a/pipefuser/modules/dit/tensor_parallel/attention.py
+++ b/pipefuser/modules/dit/tensor_parallel/attention.py
@@ -195,7 +195,7 @@ class DistriAttentionTP(BaseModule):
         dist.all_reduce(
             hidden_states,
             op=dist.ReduceOp.SUM,
-            group=distri_config.batch_group,
+            group=distri_config.batch_parallel_group,
             async_op=False,
         )
         if module.to_out[0].bias is not None:

--- a/pipefuser/modules/dit/tensor_parallel/conv2d.py
+++ b/pipefuser/modules/dit/tensor_parallel/conv2d.py
@@ -60,7 +60,7 @@ class DistriConv2dTP(BaseModule):
         dist.all_reduce(
             output,
             op=dist.ReduceOp.SUM,
-            group=distri_config.batch_group,
+            group=distri_config.batch_parallel_group,
             async_op=False,
         )
         if self.module.bias is not None:

--- a/pipefuser/modules/dit/tensor_parallel/feed_forward.py
+++ b/pipefuser/modules/dit/tensor_parallel/feed_forward.py
@@ -167,7 +167,7 @@ class DistriFeedForwardTP(BaseModule):
         dist.all_reduce(
             hidden_states,
             op=dist.ReduceOp.SUM,
-            group=distri_config.batch_group,
+            group=distri_config.batch_parallel_group,
             async_op=False,
         )
         if module.net[2].bias is not None:

--- a/pipefuser/modules/dit/tensor_parallel/resnet.py
+++ b/pipefuser/modules/dit/tensor_parallel/resnet.py
@@ -204,7 +204,7 @@ class DistriResnetBlock2DTP(BaseModule):
         dist.all_reduce(
             hidden_states,
             op=dist.ReduceOp.SUM,
-            group=distri_config.batch_group,
+            group=distri_config.batch_parallel_group,
             async_op=False,
         )
         if module.conv2.bias is not None:

--- a/pipefuser/pipelines/pip/distri_pixartalpha.py
+++ b/pipefuser/pipelines/pip/distri_pixartalpha.py
@@ -9,6 +9,8 @@ from diffusers.pipelines.pixart_alpha.pipeline_pixart_alpha import (
     retrieve_timesteps,
 )
 from typing import List, Optional, Union, Tuple, Callable, Dict, Final
+
+import torch.distributed
 from pipefuser.utils import DistriConfig, PipelineParallelismCommManager
 from pipefuser.logger import init_logger
 
@@ -19,6 +21,7 @@ class DistriPixArtAlphaPiP(PixArtAlphaPipeline):
     def init(self, distri_config: DistriConfig):
         # if distri_config.rank != 0 or distri_config.rank != distri_config.world_size - 1:
         # self.scheduler = None
+        # if torch.distributed.get_rank != 0:
         if distri_config.rank != 0:
             self.vae = None
             self.image_processor = None
@@ -48,7 +51,9 @@ class DistriPixArtAlphaPiP(PixArtAlphaPipeline):
 
         if distri_config.rank == 1:
             latents = (
-                torch.cat([latents] * 2) if do_classifier_free_guidance else latents
+                torch.cat([latents] * 2) 
+                if do_classifier_free_guidance and not self.distri_config.split_batch 
+                else latents
             )
             latents = self.scheduler.scale_model_input(latents, t)
 
@@ -80,11 +85,19 @@ class DistriPixArtAlphaPiP(PixArtAlphaPipeline):
             added_cond_kwargs=added_cond_kwargs,
             return_dict=False,
         )[0]
-
         if distri_config.rank == 0:
             # perform guidance
             if do_classifier_free_guidance:
-                noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
+                if not self.distri_config.split_batch:
+                    noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
+                else:
+                    noise_pred_uncond = torch.empty_like(noise_pred)
+                    noise_pred_text = torch.empty_like(noise_pred)
+                    torch.distributed.all_gather(
+                        [noise_pred_uncond, noise_pred_text],
+                        noise_pred,
+                        group=self.distri_config.split_group
+                    )
                 noise_pred = noise_pred_uncond + guidance_scale * (
                     noise_pred_text - noise_pred_uncond
                 )
@@ -291,10 +304,20 @@ class DistriPixArtAlphaPiP(PixArtAlphaPipeline):
             max_sequence_length=max_sequence_length,
         )
         if do_classifier_free_guidance:
-            prompt_embeds = torch.cat([negative_prompt_embeds, prompt_embeds], dim=0)
-            prompt_attention_mask = torch.cat(
-                [negative_prompt_attention_mask, prompt_attention_mask], dim=0
-            )
+            if not distri_config.split_batch:
+                prompt_embeds = torch.cat([negative_prompt_embeds, prompt_embeds], dim=0)
+                prompt_attention_mask = torch.cat(
+                    [negative_prompt_attention_mask, prompt_attention_mask], dim=0
+                )
+            else:
+                if distri_config.batch_idx() == 0:
+                    prompt_embeds = negative_prompt_embeds
+                    prompt_attention_mask = negative_prompt_attention_mask
+                elif distri_config.batch_idx() == 1:
+                    prompt_embeds = prompt_embeds
+                    prompt_attention_mask = prompt_attention_mask
+                else:
+                    raise ValueError("Invalid batch_idx")
 
         # 4. Prepare timesteps
         timesteps, num_inference_steps = retrieve_timesteps(
@@ -329,7 +352,7 @@ class DistriPixArtAlphaPiP(PixArtAlphaPipeline):
             resolution = resolution.to(dtype=prompt_embeds.dtype, device=device)
             aspect_ratio = aspect_ratio.to(dtype=prompt_embeds.dtype, device=device)
 
-            if do_classifier_free_guidance:
+            if do_classifier_free_guidance and not distri_config.split_batch:
                 resolution = torch.cat([resolution, resolution], dim=0)
                 aspect_ratio = torch.cat([aspect_ratio, aspect_ratio], dim=0)
 
@@ -361,7 +384,6 @@ class DistriPixArtAlphaPiP(PixArtAlphaPipeline):
                 else:
                     self.comm_manager.irecv_from_prev(dtype)
                     latents = self.comm_manager.get_data()
-
                 latents = self.pip_forward(
                     latents,
                     prompt_embeds,
@@ -385,7 +407,6 @@ class DistriPixArtAlphaPiP(PixArtAlphaPipeline):
                     (i + 1) > num_warmup_steps and (i + 1) % self.scheduler.order == 0
                 ):
                     progress_bar.update()
-
                 self.comm_manager.isend_to_next(latents)
 
             assert self.comm_manager.recv_queue == []
@@ -457,7 +478,7 @@ class DistriPixArtAlphaPiP(PixArtAlphaPipeline):
                 ):
                     progress_bar.update()
 
-            if distri_config.rank == 0:
+            if torch.distributed.get_rank() == 0:
                 latents = torch.cat(latents, dim=2)
             else:
                 return None

--- a/pipefuser/pipelines/pixartalpha.py
+++ b/pipefuser/pipelines/pixartalpha.py
@@ -9,6 +9,7 @@ from diffusers.pipelines.pixart_alpha.pipeline_pixart_alpha import (
     ASPECT_RATIO_512_BIN,
     ASPECT_RATIO_256_BIN,
 )
+import torch.distributed
 
 # from pipefuser.models.distri_sdxl_unet_tp import DistriUNetTP
 from pipefuser.pipelines.pip.distri_pixartalpha import DistriPixArtAlphaPiP
@@ -48,7 +49,7 @@ class DistriPixArtAlphaPipeline:
             )
 
         # assert module_config.do_classifier_free_guidance == False
-        assert module_config.split_batch == False
+        # assert module_config.split_batch == False
 
         self.distri_config = module_config
 
@@ -216,12 +217,23 @@ class DistriPixArtAlphaPipeline:
             )
 
             if distri_config.do_classifier_free_guidance:
-                prompt_embeds = torch.cat(
-                    [negative_prompt_embeds, prompt_embeds], dim=0
-                )
-                prompt_attention_mask = torch.cat(
-                    [negative_prompt_attention_mask, prompt_attention_mask], dim=0
-                )
+                if not distri_config.split_batch:
+                    prompt_embeds = torch.cat(
+                        [negative_prompt_embeds, prompt_embeds], dim=0
+                    )
+                    prompt_attention_mask = torch.cat(
+                        [negative_prompt_attention_mask, prompt_attention_mask], dim=0
+                    )
+                else:
+                    if distri_config.batch_idx() == 0:
+                        prompt_embeds = negative_prompt_embeds
+                        prompt_attention_mask = negative_prompt_attention_mask
+                    elif distri_config.batch_idx() == 1:
+                        prompt_embeds = prompt_embeds
+                        prompt_attention_mask = prompt_attention_mask
+                    else:
+                        raise ValueError("Invalid batch_idx")
+                        
 
             # Prepare added time ids & embeddings
 
@@ -240,7 +252,9 @@ class DistriPixArtAlphaPipeline:
                 None,
             )
             latent_model_input = (
-                torch.cat([latents, latents], 0) if guidance_scale > 1 else latents
+                torch.cat([latents, latents], 0) 
+                if distri_config.do_classifier_free_guidance and guidance_scale > 1 and not distri_config.split_batch
+                else latents
             )
 
             # encoder_hidden_states.shape torch.Size([2, 120, 4096])
@@ -262,7 +276,7 @@ class DistriPixArtAlphaPipeline:
                 resolution = resolution.to(dtype=prompt_embeds.dtype, device=device)
                 aspect_ratio = aspect_ratio.to(dtype=prompt_embeds.dtype, device=device)
 
-                if distri_config.do_classifier_free_guidance:
+                if distri_config.do_classifier_free_guidance and not distri_config.split_batch:
                     resolution = torch.cat([resolution, resolution], dim=0)
                     aspect_ratio = torch.cat([aspect_ratio, aspect_ratio], dim=0)
 

--- a/pipefuser/pipelines/pixartalpha.py
+++ b/pipefuser/pipelines/pixartalpha.py
@@ -184,6 +184,7 @@ class DistriPixArtAlphaPipeline:
                 use_resolution_binning=distri_config.use_resolution_binning,
                 num_inference_steps=distri_config.warmup_steps + 2,
                 output_type="latent",
+                generator=torch.Generator(device="cuda").manual_seed(42),
             )
 
         else:

--- a/scripts/pixart_example.py
+++ b/scripts/pixart_example.py
@@ -171,6 +171,8 @@ def main():
         case_name = args.output_file + "_" + case_name
     if enable_parallel_vae:
         case_name += "_patchvae"
+    if args.use_split_batch:
+        case_name += "_split_batch"
 
     if args.use_profiler:
         start_time = time.time()


### PR DESCRIPTION
* Lossless accelerated inference by splitting hidden state in batch dimension, which is 2 because of Classifier-free guidance.

## Inference speed
* pipefusion with 8 cards, 40 steps: **13.07it/s**
* pipefusion + split batch with 8 cards, splitting hidden state into 2 batch, running on 2 pipeline, each consisting of 4 cards, 40 steps: **22.08it/s**
* accelerate 1.7x on the same number of devices

## Image quality
* pipefusion parallelism with 8 cards, full pipeline.
![dog_pipefusion_hw_1024_sync_corrected_async_gn_u0_w8_mb2_warm1](https://github.com/PipeFusion/PipeFusion/assets/48981407/842366f9-03bf-40e2-9791-ce87961197be)

* pipefusion parallelism with 8 cards, split batch.
![dog_pipefusion_hw_1024_sync_corrected_async_gn_u0_w8_mb2_warm1_split_batch](https://github.com/PipeFusion/PipeFusion/assets/48981407/05a6a649-61e9-4165-9d95-5cfe4c705f26)
